### PR TITLE
Fix query param parsing and router resolver problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='drf-batch-requests',
-    version='0.8.10',
+    version='0.8.11',
     packages=['drf_batch_requests', ],
     include_package_data=True,
     license='MIT License',

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,7 +1,6 @@
 import json
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-
 from rest_framework import status
 
 from tests.mixins import APITestCase
@@ -24,12 +23,12 @@ class BaseTestCase(APITestCase):
         responses = self.forced_auth_req('post', '/batch/', data={'batch': batch})
         self.assertEqual(responses.status_code, status.HTTP_200_OK, msg=responses.data)
 
-        responses_data = list(map(lambda r: json.loads(r['body']), responses.data))
+        responses_data = [json.loads(r['body']) for r in responses.data]
 
         self.assertIn('ids', responses_data[1]['get'])
         self.assertEqual(
             responses_data[1]['get']['ids'],
-            ','.join(map(lambda o: str(o['id']), responses_data[0]['data']))
+            ','.join([str(o['id']) for o in responses_data[0]['data']])
         )
 
     def test_multipart_simple_request(self):

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,9 +1,8 @@
 from django.http import JsonResponse
-from django.views.generic import View
 from django.http.response import HttpResponse as DjangoResponse
-
-from rest_framework.views import APIView
+from django.views.generic import View
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 class TestAPIView(APIView):
@@ -15,7 +14,7 @@ class TestAPIView(APIView):
                 {'id': 3, 'some_data': 'baz'},
             ],
             'page': 1,
-            'get': {k: v[0] for k, v in request.GET.items()}
+            'get': request.query_params
         }))
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Django uses a `QueryDict` for the `HTTPRequest.GET` parameter and passing the raw result of `urlparse` is going to cause problems, e.g. non-standard data in the DRF `request.query_params` attribute.

For the query param string `?filter=foo&ordering=bar`
instead of this result: `{'filter': 'foo', 'ordering': 'bar'}`
we get this when we *don't* use `QueryDict`: `{'filter': ['foo'], 'ordering': ['bar']}`

[Check here the standard usage](https://github.com/django/django/blob/stable/1.11.x/django/http/request.py#L55)

Also when using routers, the regex can't resolve the urls with query params. (Specifically when you end your urlpatterns with `$`)

Fixed these problems and updated the tests.